### PR TITLE
Add Geocoder To the Google Maps Mock

### DIFF
--- a/gmaps.mock.api.js
+++ b/gmaps.mock.api.js
@@ -661,7 +661,8 @@ GoogleApiMock = (function() {
       this.mockMap,
       this.mockPlaces,
       this.mockSearchBox,
-      this.mockGeometry
+      this.mockGeometry,
+      this.mockGeocoder
   ];
   this.initAll = function() {
       return this.mocks.forEach(function(fn) {
@@ -1005,6 +1006,14 @@ GoogleApiMock = (function() {
       };
       return this;
   };
+  };
+  
+  GoogleApiMock.prototype.mockGeocoder = function(Geocoder) {
+    if (Geocoder == null) {
+      Geocoder = function() {
+      };
+    }
+    return window.google.maps.Geocoder = Geocoder;
   };
 
   GoogleApiMock.prototype.mockGeometry = function(geometry) {


### PR DESCRIPTION
# What
Add Geocoder mock to the Google Maps mock

# Why
It is needed when maps API request also require Geocode Data. Or if the user needs to do a direct call to the Geocode Data of a location.